### PR TITLE
Suppress console output in production

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -7,6 +7,16 @@ const init = async () => {
   console.log('Server running on %s', server.info.uri)
 }
 
+// Disable all console logging in non-development environments to prevent
+// sensitive logs or excessive output in production and pre environments.
+// This includes console.log, console.debug, console.info, and console.warn.
+if (process.env.NODE_ENV !== 'development') {
+  console.log = () => {}
+  console.debug = () => {}
+  console.info = () => {}
+  console.warn = () => {}
+}
+
 process.on('unhandledRejection', (err) => {
   console.log(err)
   process.exit(1)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ice-bank",
-  "version": "0.1.11",
+  "version": "0.1.13",
   "description": "FFC Bank microservice",
   "homepage": "https://github.com/DEFRA/ffc-ice-bank",
   "main": "app/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ice-bank",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "FFC Bank microservice",
   "homepage": "https://github.com/DEFRA/ffc-ice-bank",
   "main": "app/index.js",
@@ -21,7 +21,7 @@
     "@azure/service-bus": "^7.9.4",
     "@hapi/hapi": "21.3.2",
     "applicationinsights": "2.9.1",
-    "axios": "^1.6.7",
+    "axios": "^1.9.0",
     "dotenv": "^16.4.4"
   },
   "devDependencies": {

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -30,3 +30,43 @@ describe('Init Script', () => {
     exitSpy.mockRestore()
   })
 })
+
+describe('Console Logging', () => {
+  let originalConsoleLog, originalConsoleDebug, originalConsoleInfo, originalConsoleWarn
+
+  beforeEach(() => {
+    originalConsoleLog = console.log
+    originalConsoleDebug = console.debug
+    originalConsoleInfo = console.info
+    originalConsoleWarn = console.warn
+  })
+
+  afterEach(() => {
+    console.log = originalConsoleLog
+    console.debug = originalConsoleDebug
+    console.info = originalConsoleInfo
+    console.warn = originalConsoleWarn
+  })
+
+  test('should disable console logging in non-development environments', () => {
+    process.env.NODE_ENV = 'production'
+    require('../../app/index')
+    expect(console.log).toEqual(expect.any(Function))
+    expect(console.log()).toBeUndefined()
+    expect(console.debug).toEqual(expect.any(Function))
+    expect(console.debug()).toBeUndefined()
+    expect(console.info).toEqual(expect.any(Function))
+    expect(console.info()).toBeUndefined()
+    expect(console.warn).toEqual(expect.any(Function))
+    expect(console.warn()).toBeUndefined()
+  })
+
+  test('should not disable console logging in development environments', () => {
+    process.env.NODE_ENV = 'development'
+    require('../../app/index')
+    expect(console.log).toEqual(originalConsoleLog)
+    expect(console.debug).toEqual(originalConsoleDebug)
+    expect(console.info).toEqual(originalConsoleInfo)
+    expect(console.warn).toEqual(originalConsoleWarn)
+  })
+})


### PR DESCRIPTION
This PR disables console logging (log, debug, info, warn) outside of development environment.